### PR TITLE
Interpro updates

### DIFF
--- a/CoDIAC/InterPro.py
+++ b/CoDIAC/InterPro.py
@@ -99,6 +99,27 @@ def fetch_uniprotids(interpro_ID, REVIEWED=True, species='Homo sapiens'):
 
 
 def collect_data(entry, protein_accession, domain_database=None):
+    """
+    Given an entry from the InterPro API, collect the data for a protein accession
+    and return a dictionary with the keys 'name', 'accession', 'num_boundaries', 'boundaries'
+    where 'boundaries' is a list of dictionaries with keys 'start' and 'end'.
+    If 'short_name' is in the extra fields, this will be added to the dictionary as 'short'
+    
+    Parameters
+    ----------
+    entry: dict
+        dictionary from the InterPro API
+    protein_accession: str
+        Uniprot accession ID for a protein
+    domain_database: str
+        Domain database to search for, default is None
+    Returns
+    -------
+    dictionary: dict
+        dictionary with the keys 'name', 'accession', 'num_boundaries', 'boundaries'
+        where 'boundaries' is a list of dictionaries with keys 'start' and 'end'
+
+    """
     entry_protein_locations = entry['proteins'][0]['entry_protein_locations']
     if entry_protein_locations is None:
         entry_protein_locations = []
@@ -131,6 +152,16 @@ def get_domains(protein_accession):
     each domain dictionary has keys 'name', 'start', 'end', 'accession' (InterPro ID), 'num_boundaries' (number of this type found)
     These domains are in the order as returned by InterPro, where InterPro returns the parent nodes first. Once 
     we find domains that begin to overlap in the API response, we stop adding those to the final set of domains. 
+
+    Parameters
+    ----------
+    protein_accession: str
+        Uniprot accession ID for a protein
+    Returns
+    -------
+    d_resolved: list
+        list of dictionaries, each dictionary is a domain entry with keys 'name', 'start', 'end', 'accession', 'num_boundaries'
+
     """
     interpro_url = "https://www.ebi.ac.uk/interpro/api"
     extra_fields = ['hierarchy', 'short_name']
@@ -206,12 +237,29 @@ def resolve_domain(d_resolved, dict_entry):
     return d_resolved
 
 
-#compare the overlap of a domain to an existing set of domains.
-
-
 
 
 def generateDomainMetadata_wfilter(uniprot_accessions):
+    """
+
+    Given a list of uniprot accessions, return a dictionary of protein accessions containing domain metadata.
+    This function will return a dictionary with keys as the protein accession and values as a list of dictionaries
+    where each dictionary contains domain metadata. This metadata is collected from the InterPro API and includes
+    the keys 'interpro', 'num_children'. The 'interpro' key contains a dictionary with keys 'name', 'accession', 'num_boundaries', 'boundaries'
+    where 'boundaries' is a list of dictionaries with keys 'start' and 'end'. If 'short_name' is in the extra fields, this will be added to the dictionary as 'short'
+    This version of code uses hierarchy and children nodes to select InterPro domains. 
+
+    Parameters
+    ----------
+    uniprot_accessions: list
+        list of uniprot accessions
+    Returns
+    -------
+    metadata: dict
+        dictionary of protein accessions containing domain metadata
+    """
+
+
     interpro_url = "https://www.ebi.ac.uk/interpro/api"
     extra_fields = ['hierarchy', 'short_name']
     metadata = {}

--- a/CoDIAC/InterPro.py
+++ b/CoDIAC/InterPro.py
@@ -98,7 +98,7 @@ def fetch_uniprotids(interpro_ID, REVIEWED=True, species='Homo sapiens'):
     return(UNIPROT_ID_LIST, species_dict)
 
 
-def collect_data(entry, protein_accession, domain_database=None):
+def collect_data(entry):
     """
     Given an entry from the InterPro API, collect the data for a protein accession
     and return a dictionary with the keys 'name', 'accession', 'num_boundaries', 'boundaries'
@@ -181,7 +181,7 @@ def get_domains(protein_accession):
     for i, entry in enumerate(entry_results):
     #for i, entry in enumerate(entry_list):
         if entry['metadata']['type'] == 'domain': #get domain level only features
-            d_dict[i] = collect_data(entry, protein_accession)
+            d_dict[i] = collect_data(entry)
     d_resolved+=return_expanded_domains(d_dict[0]) # a list now: kick off the resolved domains, now start walking through and decide if taking a new domain or not.
     values = list(d_dict.keys())
     for domain_num in values[1:]:
@@ -319,7 +319,7 @@ def generateDomainMetadata_wfilter(uniprot_accessions):
                 {'interpro': data, 'num_children': num_children_list[i]}
                 for i, entry in enumerate(resp['results'])
                 if entry['metadata']['type'] == 'domain' and entry['metadata']['accession'] in top_hierarchy
-                for data in [collect_data(entry, current_accession)]
+                for data in [collect_data(entry)]
                 if data is not None
             ]
         

--- a/CoDIAC/InterPro.py
+++ b/CoDIAC/InterPro.py
@@ -179,7 +179,9 @@ def get_domains(protein_accession):
     d_dict = {} # Dictionary to store domain information for each entry
     d_resolved = []
     for i, entry in enumerate(entry_results):
-        d_dict[i] = collect_data(entry, protein_accession)
+    #for i, entry in enumerate(entry_list):
+        if entry['metadata']['type'] == 'domain': #get domain level only features
+            d_dict[i] = collect_data(entry, protein_accession)
     d_resolved+=return_expanded_domains(d_dict[0]) # a list now: kick off the resolved domains, now start walking through and decide if taking a new domain or not.
     values = list(d_dict.keys())
     for domain_num in values[1:]:
@@ -247,7 +249,7 @@ def generateDomainMetadata_wfilter(uniprot_accessions):
     where each dictionary contains domain metadata. This metadata is collected from the InterPro API and includes
     the keys 'interpro', 'num_children'. The 'interpro' key contains a dictionary with keys 'name', 'accession', 'num_boundaries', 'boundaries'
     where 'boundaries' is a list of dictionaries with keys 'start' and 'end'. If 'short_name' is in the extra fields, this will be added to the dictionary as 'short'
-    This version of code uses hierarchy and children nodes to select InterPro domains. 
+    This version of code uses hierarchy and children nodes to select InterPro domains.
 
     Parameters
     ----------

--- a/CoDIAC/InterPro.py
+++ b/CoDIAC/InterPro.py
@@ -212,9 +212,30 @@ def return_expanded_domains(domain_entry):
         domain.pop('boundaries')
     return domain_list
 
-def resolve_domain(d_resolved, dict_entry):
+def resolve_domain(d_resolved, dict_entry, threshold=0.5):
+    """
+    Given a list of resolved domains and a new domain entry, resolve the new domain entry with the existing domains
+    Keep the new domain entry if it does not overlap by more than threshold% with any existing domain. Default threshold is
+    50% (or 0.5)
+    Parameters
+    ----------
+    d_resolved: list
+        list of dictionaries, each dictionary is a domain entry with keys 'name', 'start', 'end', 'accession', 'num_boundaries'
+    dict_entry: dict
+        dictionary of domain information with that comes from collect_data on an entry. This function expands multiple domain entries, meaning that these are prioritized as they are encountered first
+    threshold: float
+        threshold for rejecting domains by overlap, default is 0.5, should be between 0 and 1
+    Returns
+    -------
+    d_resolved: list
+        list of dictionaries, each dictionary is a domain entry with keys 'name', 'start', 'end', 'accession', 'num_boundaries'
+    """
     # d_resolved is a list of dictionaries, each dictionary is a domain entry
     #setup the existing boundaries that are in d_resolved
+    if threshold < 0 or threshold > 1:
+        threshold = 0.5 #set to default
+        print("WARN: Threshold must be between 0 and 1 for rejecting domains by overlap, setting to default of 0.5")
+
     boundary_array = []
     for domain in d_resolved:
         boundary_array.append(set(range(domain['start'], domain['end'])))
@@ -231,7 +252,7 @@ def resolve_domain(d_resolved, dict_entry):
         for range_existing in boundary_array:
             #check if the set overlap between the new range and the existing range is greater than 
             # 50% of the new range. If so, do not add the new range.
-            if len(range_new.intersection(range_existing))/len(min(range_new, range_existing)) > 0.5:
+            if len(range_new.intersection(range_existing))/len(min(range_new, range_existing)) > threshold:
                 found_intersecting = True
                 break
         if not found_intersecting:


### PR DESCRIPTION
Newest functionality and behavior for Interpro. This no longer uses hierarchy and it only queries InterPro. It uses the metadata field to pull only from the domain listing (i.e. not superfamilies) and it assumes behavior that is consistent for InterPro in returning the top families of interest first. This grabs domains listed first, adding domains as long as they have no (or less than 50% as default) overlap in boundaries with existing, accepted domains. This behavior mimics the top track views of InterPro. 
Behavior: 
```domain_dict, domain_string_dict, domain_arch_dict = get_domains(uniprot_IDs)```
The domain_dict is a dictionary, keys are the uniprot ID, and the values are a list of the dictionaries with domain information. The string_dict places key information into list of strings and the arch_dict is just the domain short name separated by |. 